### PR TITLE
Make beta a passable option rather than just an env var

### DIFF
--- a/lib/openskill.ex
+++ b/lib/openskill.ex
@@ -32,7 +32,9 @@ defmodule Openskill do
       ranks: Util.default_ranks(rating_groups),
       model: Openskill.PlackettLuce,
       tau: @env.tau,
-      prevent_sigma_increase: @env.prevent_sigma_increase
+      beta: @env.beta,
+      prevent_sigma_increase: @env.prevent_sigma_increase,
+      epsilon: @env.epsilon
     ]
 
     options = Keyword.merge(defaults, options) |> Enum.into(%{})

--- a/lib/openskill/bradley_terry_full.ex
+++ b/lib/openskill/bradley_terry_full.ex
@@ -2,9 +2,9 @@ defmodule Openskill.BradleyTerryFull do
   alias Openskill.{Environment, Util}
 
   @env %Environment{}
-  @twobetasq 2 * @env.beta * @env.beta
 
-  def rate(game, _options \\ []) do
+  def rate(game, options \\ %{:beta => @env.beta, :epsilon => @env.epsilon}) do
+    twobetasq = 2 * options.beta * options.beta
     team_ratings = Util.team_rating(game)
 
     Enum.map(team_ratings, fn {teami_mu, teami_sigmasq, teami, ranki} ->
@@ -12,7 +12,7 @@ defmodule Openskill.BradleyTerryFull do
         team_ratings
         |> Enum.filter(fn {_, _, _, rankq} -> ranki != rankq end)
         |> Enum.reduce({0, 0}, fn {teamq_mu, teamq_sigmasq, _, rankq}, {omega, delta} ->
-          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + @twobetasq)
+          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + twobetasq)
           piq = 1 / (1 + Math.exp((teamq_mu - teami_mu) / ciq))
           sigsq_to_ciq = teami_sigmasq / ciq
           gamma = Math.sqrt(teami_sigmasq) / ciq
@@ -28,7 +28,7 @@ defmodule Openskill.BradleyTerryFull do
 
         {
           muij + sigmaijsq / teami_sigmasq * omegai,
-          sigmaij * Math.sqrt(max(1 - sigmaijsq / teami_sigmasq * deltai, @env.epsilon))
+          sigmaij * Math.sqrt(max(1 - sigmaijsq / teami_sigmasq * deltai, options.epsilon))
         }
       end
     end)

--- a/lib/openskill/bradley_terry_part.ex
+++ b/lib/openskill/bradley_terry_part.ex
@@ -2,9 +2,9 @@ defmodule Openskill.BradleyTerryPart do
   alias Openskill.{Environment, Util}
 
   @env %Environment{}
-  @twobetasq 2 * @env.beta * @env.beta
 
-  def rate(game, _options \\ []) do
+  def rate(game, options \\ %{:beta => @env.beta}) do
+    twobetasq = 2 * options.beta * options.beta
     team_ratings = Util.team_rating(game)
     adjacent_teams = Util.ladder_pairs(team_ratings)
 
@@ -15,7 +15,7 @@ defmodule Openskill.BradleyTerryPart do
         teami_adjacent
         |> Enum.filter(fn {_, _, _, rankq} -> ranki != rankq end)
         |> Enum.reduce({0, 0}, fn {teamq_mu, teamq_sigmasq, _, rankq}, {omega, delta} ->
-          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + @twobetasq)
+          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + twobetasq)
           piq = 1 / (1 + Math.exp((teamq_mu - teami_mu) / ciq))
           sigsq_to_ciq = teami_sigmasq / ciq
           gamma = Math.sqrt(teami_sigmasq) / ciq

--- a/lib/openskill/plackett_luce.ex
+++ b/lib/openskill/plackett_luce.ex
@@ -2,14 +2,15 @@ defmodule Openskill.PlackettLuce do
   alias Openskill.{Environment, Util}
 
   @env %Environment{}
-  @betasq @env.beta * @env.beta
 
-  def rate(game, _options \\ []) do
+  def rate(game, options \\ %{:beta => @env.beta}) do
     team_ratings = Util.team_rating(game)
+
+    betasq = options.beta * options.beta
 
     c =
       Enum.map(team_ratings, fn {_, team_sigmasq, _, _} ->
-        team_sigmasq + @betasq
+        team_sigmasq + betasq
       end)
       |> Enum.sum()
       |> Math.sqrt()

--- a/lib/openskill/thurstone_mosteller_full.ex
+++ b/lib/openskill/thurstone_mosteller_full.ex
@@ -2,10 +2,9 @@ defmodule Openskill.ThurstoneMostellerFull do
   alias Openskill.{Environment, Util}
 
   @env %Environment{}
-  @twobetasq 2 * @env.beta * @env.beta
-  @epsilon 0.1
 
-  def rate(game, _options \\ []) do
+  def rate(game, options \\ %{:beta => @env.beta, :epsilon => 0.1}) do
+    twobetasq = 2 * options.beta * options.beta
     team_ratings = Util.team_rating(game)
 
     Enum.map(team_ratings, fn {teami_mu, teami_sigmasq, teami, ranki} ->
@@ -13,7 +12,7 @@ defmodule Openskill.ThurstoneMostellerFull do
         team_ratings
         |> Enum.filter(fn {_, _, _, rankq} -> ranki != rankq end)
         |> Enum.reduce({0, 0}, fn {teamq_mu, teamq_sigmasq, _, rankq}, {omega, delta} ->
-          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + @twobetasq)
+          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + twobetasq)
           tmp = (teami_mu - teamq_mu) / ciq
           sigsq_to_ciq = teami_sigmasq / ciq
           gamma = Math.sqrt(teami_sigmasq) / ciq
@@ -21,14 +20,14 @@ defmodule Openskill.ThurstoneMostellerFull do
           cond do
             rankq > ranki ->
               {
-                omega + sigsq_to_ciq * Util.v(tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.w(tmp, @epsilon / ciq)
+                omega + sigsq_to_ciq * Util.v(tmp, options.epsilon / ciq),
+                delta + gamma * sigsq_to_ciq / ciq * Util.w(tmp, options.epsilon / ciq)
               }
 
             rankq < ranki ->
               {
-                omega + -sigsq_to_ciq * Util.v(-tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.w(-tmp, @epsilon / ciq)
+                omega + -sigsq_to_ciq * Util.v(-tmp, options.epsilon / ciq),
+                delta + gamma * sigsq_to_ciq / ciq * Util.w(-tmp, options.epsilon / ciq)
               }
 
             # the filter above ensures that rankq and ranki are never the same,
@@ -38,8 +37,8 @@ defmodule Openskill.ThurstoneMostellerFull do
             # coveralls-ignore-start
             true ->
               {
-                omega + sigsq_to_ciq * Util.vt(tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, @epsilon / ciq)
+                omega + sigsq_to_ciq * Util.vt(tmp, options.epsilon / ciq),
+                delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, options.epsilon / ciq)
               }
 
               # coveralls-ignore-stop
@@ -51,7 +50,7 @@ defmodule Openskill.ThurstoneMostellerFull do
 
         {
           muij + sigmaijsq / teami_sigmasq * omegai,
-          sigmaij * Math.sqrt(max(1 - sigmaijsq / teami_sigmasq * deltai, @env.epsilon))
+          sigmaij * Math.sqrt(max(1 - sigmaijsq / teami_sigmasq * deltai, options.epsilon))
         }
       end
     end)

--- a/lib/openskill/thurstone_mosteller_part.ex
+++ b/lib/openskill/thurstone_mosteller_part.ex
@@ -2,10 +2,9 @@ defmodule Openskill.ThurstoneMostellerPart do
   alias Openskill.{Environment, Util}
 
   @env %Environment{}
-  @twobetasq 2 * @env.beta * @env.beta
-  @epsilon 0.1
 
-  def rate(game, _options \\ []) do
+  def rate(game, options \\ %{:beta => @env.beta, :epsilon => 0.1}) do
+    twobetasq = 2 * options.beta * options.beta
     team_ratings = Util.team_rating(game)
     adjacent_teams = Util.ladder_pairs(team_ratings)
 
@@ -16,7 +15,7 @@ defmodule Openskill.ThurstoneMostellerPart do
         teami_adjacent
         |> Enum.filter(fn {_, _, _, rankq} -> ranki != rankq end)
         |> Enum.reduce({0, 0}, fn {teamq_mu, teamq_sigmasq, _, rankq}, {omega, delta} ->
-          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + @twobetasq)
+          ciq = Math.sqrt(teami_sigmasq + teamq_sigmasq + twobetasq)
           tmp = (teami_mu - teamq_mu) / ciq
           sigsq_to_ciq = teami_sigmasq / ciq
           gamma = Math.sqrt(teami_sigmasq) / ciq
@@ -24,14 +23,14 @@ defmodule Openskill.ThurstoneMostellerPart do
           cond do
             rankq > ranki ->
               {
-                omega + sigsq_to_ciq * Util.v(tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.w(tmp, @epsilon / ciq)
+                omega + sigsq_to_ciq * Util.v(tmp, options.epsilon / ciq),
+                delta + gamma * sigsq_to_ciq / ciq * Util.w(tmp, options.epsilon / ciq)
               }
 
             rankq < ranki ->
               {
-                omega + -sigsq_to_ciq * Util.v(-tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.w(-tmp, @epsilon / ciq)
+                omega + -sigsq_to_ciq * Util.v(-tmp, options.epsilon / ciq),
+                delta + gamma * sigsq_to_ciq / ciq * Util.w(-tmp, options.epsilon / ciq)
               }
 
             # the filter above ensures that rankq and ranki are never the same,
@@ -41,8 +40,8 @@ defmodule Openskill.ThurstoneMostellerPart do
             # coveralls-ignore-start
             true ->
               {
-                omega + sigsq_to_ciq * Util.vt(tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, @epsilon / ciq)
+                omega + sigsq_to_ciq * Util.vt(tmp, options.epsilon / ciq),
+                delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, options.epsilon / ciq)
               }
 
               # coveralls-ignore-stop
@@ -54,7 +53,7 @@ defmodule Openskill.ThurstoneMostellerPart do
 
         {
           muij + sigmaijsq / teami_sigmasq * omegai,
-          sigmaij * Math.sqrt(max(1 - sigmaijsq / teami_sigmasq * deltai, @env.epsilon))
+          sigmaij * Math.sqrt(max(1 - sigmaijsq / teami_sigmasq * deltai, options.epsilon))
         }
       end
     end)

--- a/test/openskill_test.exs
+++ b/test/openskill_test.exs
@@ -165,7 +165,8 @@ defmodule OpenskillTest do
       [[a2], [b2], [c2], [d2]] =
         Openskill.rate(
           [[a1], [b1], [c1], [d1]],
-          model: Openskill.ThurstoneMostellerPart
+          model: Openskill.ThurstoneMostellerPart,
+          epsilon: 0.1
         )
 
       assert [


### PR DESCRIPTION
This is a trivial refactor that makes `beta` possible to pass as an option to `rate`. Pamabama wanted to run some tests using that.

I also made `epsilon` a variable like that, along the way.

If there's a way to do this in a cleaner way, I'd be happy to know about it!